### PR TITLE
feat: added more fields to application-v1.json

### DIFF
--- a/schema/application-v1.json
+++ b/schema/application-v1.json
@@ -9,7 +9,24 @@
       "Data Owner Country/Region": "",
       "Data Owner Industry": "",
       "Website": 0,
-      "Social Media": ""
+      "Social Media": "",
+      "What is your role related to the dataset": "",
+      "Total amount of DataCap being requested": {
+        "amount": 0,
+        "unit": ""
+      },
+      "Expected size of single dataset (one copy)": {
+        "amount": "",
+        "unit": ""
+      },
+      "Number of replicas to store": 0,
+      "Weekly allocation of DataCap requested": {
+        "amount": "",
+        "unit": ""
+      },
+      "On-chain address for first allocation": "",
+      "Data Type of Application": "Slingshot | Public, Open Dataset (Research/Non-Profit) | Public, Open Commercial/Enterprise | Private Commercial/Enterprise | Private Non-Profit / Social impact",
+      "Custom multisig": ""
     },
     "projectDetails": {
       "Share a brief history of your project and organization": "",


### PR DESCRIPTION
Added some fields that are available on the frontend but were missing from the schema:

```json
"What is your role related to the dataset": "",
"Total amount of DataCap being requested": {
  "amount": 0,
  "unit": ""
},
"Expected size of single dataset (one copy)": {
  "amount": "",
  "unit": ""
},
"Number of replicas to store": 0,
"Weekly allocation of DataCap requested": {
  "amount": "",
  "unit": ""
},
"On-chain address for first allocation": "",
"Data Type of Application": "Slingshot | Public, Open Dataset (Research/Non-Profit) | Public, Open Commercial/Enterprise | Private Commercial/Enterprise | Private Non-Profit / Social impact",
"Custom multisig": ""
```